### PR TITLE
Prevent "Undefined offset" notice

### DIFF
--- a/spec/Console/ConsoleOptionParserSpec.php
+++ b/spec/Console/ConsoleOptionParserSpec.php
@@ -114,6 +114,21 @@ describe('ConsoleOptionParser', function() {
             ]);
         });
 
+        it('ignores option arguments at final position', function() use ($addOptions) {
+            $parser = new ConsoleOptionParser();
+            $addOptions($parser);
+
+            $parser->parseArguments(['--reporter']);
+            $options = $parser->getOptions();
+
+            expect($options)->toEqual([
+                'watch'    => false,
+                'ascii'    => false,
+                'reporter' => false,
+                'filter'   => false
+            ]);
+        });
+
         it('stores invalid options', function() use ($addOptions) {
             $parser = new ConsoleOptionParser();
             $addOptions($parser);

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -146,9 +146,11 @@ class ConsoleOptionParser
             // It's a valid option and accepts arguments, add the next argument
             // as its value. Otherwise, just set the option to true
             $option = $this->getConsoleOption($args[$i]);
-            if ($option->acceptsArguments() && $i < count($args)) {
-                $option->setValue($args[$i + 1]);
-                $i++;
+            if ($option->acceptsArguments()) {
+                if (isset($args[$i+1])) {
+                    $option->setValue($args[$i + 1]);
+                    $i++;
+                }
             } else {
                 $option->setValue(true);
             }


### PR DESCRIPTION
Fixes an issue where, when an optional argument was at the final position in the argument list, a notice was being generated:

```
$ pho --reporter
PHP Notice:  Undefined offset: 1 in /Users/nstory/.composer/vendor/danielstjules/pho/src/Console/ConsoleOptionParser.php on line 150
PHP Stack trace:
PHP   1. {main}() /Users/nstory/.composer/vendor/danielstjules/pho/bin/pho:0
PHP   2. require_once() /Users/nstory/.composer/vendor/danielstjules/pho/bin/pho:28
PHP   3. pho\Console\Console->parseArguments() /Users/nstory/.composer/vendor/danielstjules/pho/src/pho.php:137
PHP   4. pho\Console\ConsoleOptionParser->parseArguments() /Users/nstory/.composer/vendor/danielstjules/pho/src/Console/Console.php:130

Notice: Undefined offset: 1 in /Users/nstory/.composer/vendor/danielstjules/pho/src/Console/ConsoleOptionParser.php on line 150

Call Stack:
    0.0008     228816   1. {main}() /Users/nstory/.composer/vendor/danielstjules/pho/bin/pho:0
    0.0022     372704   2. require_once('/Users/nstory/.composer/vendor/danielstjules/pho/src/pho.php') /Users/nstory/.composer/vendor/danielstjules/pho/bin/pho:28
    0.0029     473216   3. pho\Console\Console->parseArguments() /Users/nstory/.composer/vendor/danielstjules/pho/src/pho.php:137
    0.0030     490104   4. pho\Console\ConsoleOptionParser->parseArguments() /Users/nstory/.composer/vendor/danielstjules/pho/src/Console/Console.php:130
```
