### PR TITLE
Preserve globals for bootstrap files

### DIFF
--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -169,11 +169,6 @@ class Runner
      */
     public function run()
     {
-        if (self::$console->options['bootstrap'] &&
-            !$this->loadBootstrap(self::$console->options['bootstrap'])) {
-            return;
-        }
-
         // Get and instantiate the reporter class, load files
         $reporterClass = self::$console->getReporterClass();
         $this->reporter = new $reporterClass(self::$console);
@@ -339,26 +334,5 @@ class Runner
         if ($runnable instanceof Runnable) {
             $runnable->run();
         }
-    }
-
-    /**
-     * Loads a bootstrap file given its string path.
-     *
-     * @param  string $bootstrap Path to the bootstrap file to load
-     * @return bool   Whether or not the file was successfully loaded
-     */
-    private function loadBootstrap($bootstrap)
-    {
-        if (!file_exists($bootstrap)) {
-            self::$console->writeLn("Bootstrap file not found: $bootstrap");
-        } else if(!is_readable($bootstrap)) {
-            self::$console->writeLn("Bootstrap file not readable: $bootstrap");
-        } else if(!@include_once($bootstrap)) {
-            self::$console->writeLn("Unable to include bootstrap: $bootstrap");
-        } else {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/pho.php
+++ b/src/pho.php
@@ -187,6 +187,22 @@ if (!$console->options['namespace']) {
     require_once($path);
 }
 
+// Bootstrap file must be required directly rather than from function
+// invocation to preserve any loaded globals
+$bootstrap = $console->options['bootstrap'];
+if ($bootstrap) {
+    if (!file_exists($bootstrap)) {
+        $console->writeLn("Bootstrap file not found: $bootstrap");
+        exit(1);
+    } else if(!is_readable($bootstrap)) {
+        $console->writeLn("Bootstrap file not readable: $bootstrap");
+        exit(1);
+    } else if(!@include_once($bootstrap)) {
+        $console->writeLn("Unable to include bootstrap: $bootstrap");
+        exit(1);
+    }
+}
+
 // Files must be required directly rather than from function
 // invocation to preserve any loaded globals
 $paths = expandPaths($console->getPaths());


### PR DESCRIPTION
#21 has worked great but it obviously didn't change the way bootstrap files are loaded, so I lost globals when trying to use it.  This change is essentially the same thing but it pulls the loadBootstrap function out of the Runner and into src/pho.php
